### PR TITLE
Ensure compiled java output is utf-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,10 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 // Example for how to get properties into the manifest for reading at runtime.
 jar {
     manifest {


### PR DESCRIPTION
Adds

```
tasks.withType(JavaCompile).configureEach {
    options.encoding = 'UTF-8'
}
```
to build.gradle.

The is standard practice, and should always be done.